### PR TITLE
Remove disk metrics from the workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Whilst running directly on a host, details can be pulled from pustil (which
 pulls data from the `/proc` tree, however in a docker image the correct place
 to pull this data is from the `/sys/fs/cgroup/`)
 
+### August 2020 Flaw Found
+
+In August 2020, we found a flaw in our logic: The code that determined the disk
+metrics stalled the loading to the classic notebook-server intreface for those
+with >~8,000 items under $HOME (in our K8 environment.)
+
+This code-base has been edited to it does not interact with that metric (it
+doesn't generate it, or look to display it in the UI)
+
 ## Installation
 
 You currently install this package by cloning from GitHub. In your dockerfile, add:

--- a/nbresuse/metrics.py
+++ b/nbresuse/metrics.py
@@ -92,10 +92,10 @@ class PSUtilMetricsLoader:
             self.config.process_cpu_metrics, self.config.system_cpu_metrics
         )
 
-    def disk_metrics(self):
-        root_directory = Path(self.config.disk_dir)
-        disk_usage = sum(
-            f.stat().st_size for f in root_directory.glob("**/*") if f.is_file()
-        )
-        disk_psutils = psutil.disk_usage(self.config.disk_dir).total
-        return {"disk_usage": disk_usage, "disk_total": disk_psutils}
+    # def disk_metrics(self):
+    #     root_directory = Path(self.config.disk_dir)
+    #     disk_usage = sum(
+    #         f.stat().st_size for f in root_directory.glob("**/*") if f.is_file()
+    #     )
+    #     disk_psutils = psutil.disk_usage(self.config.disk_dir).total
+    #     return {"disk_usage": disk_usage, "disk_total": disk_psutils}

--- a/nbresuse/prometheus.py
+++ b/nbresuse/prometheus.py
@@ -43,11 +43,11 @@ class PrometheusHandler(Callable):
             if cpu_metric_values is not None:
                 self.TOTAL_CPU_USAGE.set(cpu_metric_values["cpu_percent"])
                 self.MAX_CPU_USAGE.set(self.apply_cpu_limit(cpu_metric_values))
-        if self.config.track_disk_usage:
-            disk_metric_values = self.metricsloader.disk_metrics()
-            if disk_metric_values is not None:
-                self.TOTAL_DISK_USAGE.set(disk_metric_values["disk_usage"])
-                self.MAX_DISK_USAGE.set(self.apply_disk_limit(disk_metric_values))
+        # if self.config.track_disk_usage:
+        #     disk_metric_values = self.metricsloader.disk_metrics()
+        #     if disk_metric_values is not None:
+        #         self.TOTAL_DISK_USAGE.set(disk_metric_values["disk_usage"])
+        #         self.MAX_DISK_USAGE.set(self.apply_disk_limit(disk_metric_values))
 
     def apply_memory_limit(self, memory_metric_values) -> Optional[int]:
         if memory_metric_values is None:

--- a/nbresuse/static/main.js
+++ b/nbresuse/static/main.js
@@ -146,7 +146,7 @@ define([
             success: function(data) {
                 displayMetric('memory', data)
                 displayMetric('cpu', data)
-                displayMetric('disk', data)
+                // displayMetric('disk', data)
             }
         });
     };


### PR DESCRIPTION
As per the README update: the disk metrics stall the startup of notebooks with a large number of objects

Simply hides the disk processing stuff, but doesn't actually delete it.